### PR TITLE
Loaded sources

### DIFF
--- a/src/chrome/client/eventSender.ts
+++ b/src/chrome/client/eventSender.ts
@@ -64,7 +64,6 @@ export class EventSender implements IEventsToClientReporter {
     }
 
     public async sendSourceWasLoaded(params: SourceWasLoadedParameters): Promise<void> {
-        // TODO DIEGO: Should we be using the source tree instead of the source here?
         const clientSource = await this._internalToClient.toSource(params.source);
         const event = new LoadedSourceEvent(params.reason, clientSource);
 

--- a/src/chrome/internal/sources/features/notifyClientOfLoadedSources.ts
+++ b/src/chrome/internal/sources/features/notifyClientOfLoadedSources.ts
@@ -64,10 +64,7 @@ export class NotifyClientOfLoadedSources implements IComponent {
                 telemetry.reportEvent('LoadedSourceEventError', { issue: 'Unknown reason', reason: loadedSourceEventReason });
         }
 
-        // TODO DIEGO: Should we be using the source tree here?
-        // const sourceTree = this._sourcesLogic.getLoadedSourcesTree(script.script);
-
-        this._eventsToClientReporter.sendSourceWasLoaded({ reason: loadedSourceEventReason, source: script.developmentSource });
+        this._eventsToClientReporter.sendSourceWasLoaded({ reason: loadedSourceEventReason, source: script.runtimeSource });
     }
 
     constructor(


### PR DESCRIPTION
Loaded Scripts should show the runtime source, not the dev source on disk.

Not sure about the TODOs, is that for VS? I don't think vscode needs the tree currently.